### PR TITLE
Setup multiarch builds

### DIFF
--- a/sensor/Dockerfile.template
+++ b/sensor/Dockerfile.template
@@ -9,8 +9,7 @@ RUN pip3 install --user -r /requirements.txt
 COPY . .
 RUN mkdir -p /app/components/secrets
 
-RUN wget -q https://github.com/dapr/dapr/releases/download/v1.0.1/daprd_linux_amd64.tar.gz
-RUN tar -zxvf daprd_linux_amd64.tar.gz
+RUN ./download.sh "%%BALENA_ARCH%%"
 
 ENV PATH /app:$PATH
 

--- a/sensor/build-image.sh
+++ b/sensor/build-image.sh
@@ -7,27 +7,31 @@ function build_and_push_image () {
   local DOCKER_REPO=$1
   local BALENA_MACHINE_NAME=$2
   local DOCKER_ARCH=$3
+  local BALENA_ARCH=$4
 
   echo "Building for machine name $BALENA_MACHINE_NAME, platform $DOCKER_ARCH, pushing to $DOCKER_REPO/$BLOCK_NAME"
 
   sed "s/%%BALENA_MACHINE_NAME%%/$BALENA_MACHINE_NAME/g" ./Dockerfile.template > ./Dockerfile.$BALENA_MACHINE_NAME
-  
-  docker buildx build -t $DOCKER_REPO/$BLOCK_NAME:latest --load --platform $DOCKER_ARCH --file Dockerfile.$BALENA_MACHINE_NAME .
+  sed -i.bak "s/%%BALENA_ARCH%%/$BALENA_ARCH/g" ./Dockerfile.$BALENA_MACHINE_NAME && rm ./Dockerfile.$BALENA_MACHINE_NAME.bak
+  docker buildx build -t $DOCKER_REPO/$BLOCK_NAME:$BALENA_MACHINE_NAME --load --platform $DOCKER_ARCH --file Dockerfile.$BALENA_MACHINE_NAME .
 
   echo "Publishing..."
-  docker push $DOCKER_REPO/$BLOCK_NAME:latest # comment this out when we have multiarch and use the manifest
+  docker push $DOCKER_REPO/$BLOCK_NAME:$BALENA_MACHINE_NAME
 
   echo "Cleaning up..."
   rm Dockerfile.$BALENA_MACHINE_NAME
 }
 
 function create_and_push_manifest() {
-  docker manifest create $DOCKER_REPO/$BLOCK_NAME:latest --amend $DOCKER_REPO/$BLOCK_NAME:genericx86-64-ext
+  docker manifest create $DOCKER_REPO/$BLOCK_NAME:latest --amend $DOCKER_REPO/$BLOCK_NAME:genericx86-64-ext \
+     --amend $DOCKER_REPO/$BLOCK_NAME:raspberrypi4-64 --amend $DOCKER_REPO/$BLOCK_NAME:fincm3
   docker manifest push $DOCKER_REPO/$BLOCK_NAME:latest
 }
 
 # You can pass in a repo (such as a test docker repo) or accept the default
 DOCKER_REPO=${1:-balenablocks}
-build_and_push_image $DOCKER_REPO "genericx86-64-ext" "linux/amd64"
+build_and_push_image $DOCKER_REPO "genericx86-64-ext" "linux/amd64" "amd64"
+build_and_push_image $DOCKER_REPO "raspberrypi4-64" "linux/arm64" "aarch64"
+build_and_push_image $DOCKER_REPO "fincm3" "linux/arm/v7" "armv7hf"
 
-# create_and_push_manifest
+create_and_push_manifest

--- a/sensor/download.sh
+++ b/sensor/download.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+outfile="/tmp/daprd.tar.gz"
+download_base="https://github.com/dapr/dapr/releases/download/v1.0.1/"
+
+case $1 in
+   aarch64) package_file="daprd_linux_arm64.tar.gz"
+       ;;
+   amd64) package_file="daprd_linux_amd64.tar.gz"
+       ;;
+    *) package_file="daprd_linux_arm.tar.gz"
+esac
+wget -O "${outfile}" "${download_base}${package_file}"
+
+tar -xvf /tmp/daprd.tar.gz


### PR DESCRIPTION
To date builds have been hard-coded to target the amd64 architecture. This PR allows a user to select the architecture for a build. Specifically, there are two changes in this PR:

* Use BALENA_ARCH variable in `Dockerfile.template` to download the correct daprd executable
* Update `build-image.sh` for the change to `Dockerfile.template`, and create an image manifest entry for each architecture.

Closes #32