### PR TITLE
Store environment variables locally for component configuration

### DIFF
--- a/sensor/run.sh
+++ b/sensor/run.sh
@@ -5,19 +5,7 @@ then
     DAPR_LOGLEVEL="--log-level debug"
 fi
 
-# Load information from secrets plugins
-if python3 ./src/autoconfigure.py secrets
-then
-    sleep 3
-    daprd $DAPR_LOGLEVEL --components-path /app/components/secrets --app-id $1 &
-    DAPR_PID=$!
-    sleep 3
-    `python3 ./src/getSecrets.py` # environment variables are applied from stdout
-    kill -SIGTERM "$DAPR_PID"
-    sleep 5
-fi
-
-# Initialize input and out plugins
+# Initialize dapr services from plugins
 python3 ./src/autoconfigure.py
 sleep 3
 daprd $DAPR_LOGLEVEL --components-path /app/components --app-protocol grpc --app-port 50051 --app-id $1 &

--- a/sensor/src/README.md
+++ b/sensor/src/README.md
@@ -1,0 +1,58 @@
+# dapr Component Plugins
+
+The cloud block uses the [PluginBase](http://pluginbase.pocoo.org/) mechanism to identify and configure dapr components. The configuration program finds the expected variable names coded in each plugin and writes a dapr configuration file with the user supplied variable values.
+
+Plugin files must be added in the `plugins` directory. There are two files for each plugin: the `.py` plugin file itself, and a corresponding template `.yaml` file.
+
+## Python file
+A plugin is a Python formatted  `.py` file, containing four definitions:
+
+| Variable | Contents                                            |
+|----------|-----------------------------------------------------|
+| NAME     | Name of plugin (arbitrary)                          |
+| TYPE     | Class of plugin; see description below              |
+| FILE     | File containing dapr yaml definition template       |
+| VARS     | List of variables required by YAML file             |
+
+Example:
+
+```
+NAME = "GCP Pubsub"
+TYPE = "output"
+FILE = "GcpPubsubOutput.yaml"
+VARS = [
+    "GCP_PUBSUB_TOPIC",
+    "GCP_PUBSUB_TYPE",
+    "GCP_PUBSUB_PROJECT_ID",
+]
+```
+
+A plugin TYPE must be one of the items in the table below.
+
+| Type   | Description                                  |
+|--------|----------------------------------------------|
+| output |dapr definition to write output data to cloud |
+| input  |dapr definition to read input data from device|
+| secret |dapr definition to read a secret store        |
+
+## YAML file
+The YAML file is a template in the form required by dapr to configure a component. An attribute value in the form `!ENV ${<var-name>}` specifies a placeholder for the real value to be replaced by the configuration program.
+
+Example:
+
+```
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: message-queue
+spec:
+  type: bindings.gcp.pubsub
+  version: v1
+  metadata:
+  - name: topic
+    value: !ENV ${GCP_PUBSUB_TOPIC}
+  - name: type
+    value: !ENV ${GCP_PUBSUB_TYPE}
+  - name: project_id
+    value: !ENV ${GCP_PUBSUB_PROJECT_ID}
+```

--- a/sensor/src/autoconfigure.py
+++ b/sensor/src/autoconfigure.py
@@ -4,6 +4,16 @@ import yaml
 from yamlVariableResolver import Resolver
 from util import get_plugin_source
 
+def _read_value(var_name):
+    """Read and scrub environment variable value
+
+    :return: variable value or None if not found
+    """
+    raw_value = os.getenv(var_name)
+    if not raw_value:
+        return None
+    return raw_value.replace("\\n", "\n")
+
 def invoke_plugin(plugin):
     pluginDirectory = "./plugins/"
     componentDirectory = "/app/components/"
@@ -17,7 +27,8 @@ def invoke_plugin(plugin):
         # don't need to do anything here
         None
 
-    variables = {var: os.getenv(var) for var in plugin.VARS}
+    # load dictionary of variable names/values expected by template
+    variables = {var: _read_value(var) for var in plugin.VARS}
 
     # if all the variables are empty, we're not configuring the plugin, so we can quit
     if not any(variables.values()):
@@ -36,7 +47,7 @@ def invoke_plugin(plugin):
         return False
 
     # Use the custom YAML loader to resolve the inline variables 
-    output = Resolver.resolve(pluginDirectory + plugin.FILE)
+    output = Resolver.resolve(pluginDirectory + plugin.FILE, variables)
     print("{name} will be configured with:".format(name=plugin.NAME))
     print(str(output))
 

--- a/sensor/src/util.py
+++ b/sensor/src/util.py
@@ -3,7 +3,9 @@ from functools import partial
 from pluginbase import PluginBase
 
 def get_plugin_source():
-    # Use PluginBase to find the plugins
+    """Creates and returns a 'plugin_source' object as defined by PluginBase,
+       which provides access plugins.
+    """
     here = os.path.abspath(os.path.dirname(__file__))
     get_path = partial(os.path.join, here)
     plugin_base = PluginBase(package='plugins')

--- a/sensor/src/yamlVariableResolver.py
+++ b/sensor/src/yamlVariableResolver.py
@@ -7,29 +7,39 @@ import yaml
 
 class Resolver():
 
-    ################
-    # Load a yaml configuration file and resolve any environment variables
-    # The environment variables must have !ENV before them and be in this format
-    # to be parsed: ${VAR_NAME}.
-    ################
     def resolve(path=None, data=None, tag='!ENV'):
+        """
+        Load a templated YAML configuration file, and substitute values from the
+        provided 'data' dictionary into named tags marked in the file. A named tag
+        is in the form: "<tag> ${<name>}". In this text:
 
-        # pattern for global vars: look for ${variable}
+            Lorem ipsum !ENV ${GCP_PUBSUB_TOPIC} sit amet
+
+        the tag is "!ENV" and the name is "GCP_PUBSUB_TOPIC". If the value in 'data'
+        for the key 'GCP_PUBSUB_TOPIC' is 'dolet', the result is:
+
+            Lorem ipsum dolet sit amet
+
+        :tag: Identifier for a <tag>
+        :data: dictionary, where a key is the <name> for a tag, and a value is the
+        value to be substituted for the named tag
+        :return: loaded YAML list/dictionary with substituted text
+        """
+
+        # pattern for tag name
         pattern = re.compile('.*?\${(\w+)}.*?')
         loader = yaml.SafeLoader
 
-        # the tag will be used to mark where to start searching for the pattern
-        # e.g. somekey: !ENV somestring${MYENVVAR}blah blah blah
         loader.add_implicit_resolver(tag, pattern, None)
 
-        ################
-        # Extracts the environment variable from the node's value
-        # :param yaml.Loader loader: the yaml loader
-        # :param node: the current node in the yaml
-        # :return: the parsed string that contains the value of the environment
-        # variable
-        ################
-        def constructor_env_variables(loader, node):
+        def value_constructor(loader, node):
+            """
+            Extracts the environment variable from the node's value
+            
+            :param yaml.Loader loader: the yaml loader
+            :param node: the current node in the yaml
+            :return: the parsed string that contains the value
+            """
             value = loader.construct_scalar(node)
             match = pattern.findall(value)  # to find all env variables in line
             if match:
@@ -40,7 +50,7 @@ class Resolver():
                 return full_value
             return value
 
-        loader.add_constructor(tag, constructor_env_variables)
+        loader.add_constructor(tag, value_constructor)
         # Change directory to this file's location
         os.chdir(os.path.dirname(__file__))
 

--- a/sensor/src/yamlVariableResolver.py
+++ b/sensor/src/yamlVariableResolver.py
@@ -35,9 +35,8 @@ class Resolver():
             if match:
                 full_value = value
                 for g in match:
-                    full_value = full_value.replace(
-                        f'${{{g}}}', os.environ.get(g, g)
-                    )
+                    full_value = full_value.replace(f'${{{g}}}', data[g])
+                #print("full_value is {}".format(full_value))
                 return full_value
             return value
 
@@ -48,7 +47,5 @@ class Resolver():
         if path:
             with open(path) as conf_data:
                 return yaml.load(conf_data, Loader=loader)
-        elif data:
-            return yaml.load(data, Loader=loader)
         else:
-            raise ValueError('Either a path or data should be passed in. Exiting.')
+            raise ValueError('Path must be passed in. Exiting.')


### PR DESCRIPTION
This PR is the first step in resolving #39, Refactor collection/use of component configuration parameters. It reworks direct component configuration, i.e. not secrets based. Secrets based component configuration will be unavailable until addressed in a future PR.

Relative to the outline in #39, this PR implements steps 1 and 3. Notice these features:

As environment variables are identified in `write_config()` from the plugin VARS list, they are saved in a dictionary.

`Resolver.resolve()` now expects the `data` parameter to be the variable dictionary. It uses this dictionary to substitute the variable value into the YAML file text as the file is read. It does not read the variable from the OS environment again.

`write_config()` now calls a separate `_read_value()` method. This method allows for extra processing of the value read from the environment. In particular it handles doubled backslash escapes, which are found in the GCP secret key variable.

# Testing
The [kb2ma/cloudBlock-test](https://github.com/kb2ma/cloudBlock-test) repository provides two convenient test projects, _mock-data_ and _sensor_, which reference the kb2ma/cloud-dev repository on Docker. Presently this Docker repo includes images built from this PR.
