### PR TITLE
Read secrets in a single process to write component configurations

### DIFF
--- a/sensor/Dockerfile.template
+++ b/sensor/Dockerfile.template
@@ -14,7 +14,7 @@ ENV PATH=/root/.local/bin:$PATH
 WORKDIR /app
 COPY . .
 RUN chmod +x *.sh
-RUN mkdir -p /app/components/secrets
+RUN mkdir -p /app/components
 
 RUN install_packages wget tar libstdc++
 

--- a/sensor/non-output-components.txt
+++ b/sensor/non-output-components.txt
@@ -1,0 +1,5 @@
+# Component names for non-output components
+awssecretsmanager
+gcpsecretmanager
+keyvault
+mqtt-input

--- a/sensor/src/getSecrets.py
+++ b/sensor/src/getSecrets.py
@@ -1,32 +1,72 @@
+"""
+Provides access to a secret store via dapr. Starts and manages a dapr process,
+which provides HTTP access to the store.
+
+Assumes daprd executable in same directory as currently running process.
+
+Usage:
+    * open()
+    * read_value() -- as needed
+    * close() -- Must terminate the daprd process!
+
+Copyright 2021 balena inc.
+"""
 import time
 import requests
 import os
+import subprocess
 import sys
-from util import get_plugin_source
+import time
+
+# Used to retrieve a secret; must be configured when opening the store
+secrets_url = ""
+
+# Popen object for the daprd process, or None if not started
+dapr = None
+
+def open(url_name, component_directory, is_debug_logging):
+    """Opens the secret store so values may be read. Starts dapr process.
+
+    :param url_name: Segment of URL with the name configured for the secret store
+    :return: True on successful open; False otherwise
+    """
+    global secrets_url, dapr
+    dapr_port = os.getenv("DAPR_HTTP_PORT", 3500)
+    secrets_url = "http://localhost:{}/v1.0/secrets/{}/".format(dapr_port, url_name)
+
+    args = ['daprd', '--components-path', component_directory, '--app-id', 'cloudBlock']
+    if is_debug_logging:
+        args.extend(['--log-level', 'debug'])
+    print("Starting daprd process")
+    try:
+        dapr = subprocess.Popen(args)
+        time.sleep(3)
+    except Exception as e:
+        print("Error starting daprd: {}".format(e))
+        return False
+    return True
+
+def close():
+    """Terminates dapr process"""
+    if dapr:
+        print("Terminating daprd process")
+        try:
+            dapr.terminate()
+            time.sleep(5)
+        except Exception as e:
+            print("Error terminating daprd: {}".format(e))
+    else:
+        print("daprd process not found; can't terminate it")
 
 
-def log(message):
-    # Use stderr for logs / debug messages as stdout is used for env variables
-    sys.stderr.write("{0}\n".format(message))
-    sys.stderr.flush()
+def read_value(secret_name):
+    """Reads the value for the provided name in the secret store.
 
-dapr_port = os.getenv("DAPR_HTTP_PORT", 3500)
-secrets_url = "http://localhost:{}/v1.0/secrets/keyvault/".format(dapr_port)
-
-variables = {}
-plugin_source = get_plugin_source()
-for plugin_name in plugin_source.list_plugins():
-    plugin = plugin_source.load_plugin(plugin_name)
-
-    if plugin.TYPE == "secrets":
-        continue
-
-    for var in plugin.VARS:
-        variables[var.replace("_", "-").lower()] = var
-
-try:
-    for secret_name, variable_name in variables.items():
-        log("Looking for {0}".format(secret_name))
+    :return: secret value or None if not found
+    """
+    value = None
+    try:
+        print("Looking for {}".format(secret_name))
         url = secrets_url + secret_name
         response = requests.get(url)
         json_data = response.json()
@@ -34,14 +74,14 @@ try:
         if response.status_code != 200:
             if "message" in json_data and "StatusCode=404" in json_data["message"]:
                 # Secret not found, we do not care
-                continue
+                pass
+            else:
+                # Any other failure - log the details
+                print("Getting secret failed with status code {}".format(response.status_code))
+                print("Response: {}".format(json_data))
 
-            # Any other failure - log the details
-            log("Getting secrets failed with status code {code}".format(code=response.status_code))
-            log("Response: {response}".format(response=json_data))
-            continue
+        value = json_data[secret_name]
 
-        log("{0} secret found, populating {1} env variable".format(secret_name, variable_name))
-        print("export {0}={1}".format(variable_name, json_data[secret_name]))
-except Exception as e:
-    log(e)
+    except Exception as e:
+        print("Error retrieving secret: {}".format(e))
+    return value

--- a/sensor/src/plugins/AzureSecretsKeyvault.yaml
+++ b/sensor/src/plugins/AzureSecretsKeyvault.yaml
@@ -12,4 +12,4 @@ spec:
   - name: spnClientId
     value: !ENV ${AZURE_VAULT_CLIENT_ID}
   - name: spnCertificateFile
-    value: /app/components/secrets/azure-vault-cert.pfx
+    value: /app/components/azure-vault-cert.pfx


### PR DESCRIPTION
This PR resolves #39, Refactor collection/use of component configuration parameters. It implements step 2 in the outline for that issue, to read secrets from a secret store via dapr. Any secrets found are used to configure other dapr based components. The innovation with this PR is that this read-secret and write-configuration cycle occurs within a single Python process.

There is a significant amount of change in this single PR. To make the changes easier to review, the table below provides a summary.

#### 0a9002a
Converts `getSecrets.py` to a callable module rather than a standalone. See comment at top of file.

#### 1aa33f2
Extensive rework to use getSecrets (secret_reader). See the variable definitions at top and the procedural code at bottom.  `configure()` now only handles a single plugin type at a time. Secret store config file now placed in same directory as input/output components.  See `_read_value()` for query of secrets in the store as well as environment variables.

Creation of `secret_store_urls` dictionary was the easiest way to determine the URL for the secret store. We could read the `.py` and `.yaml` files on the fly to avoid hard-coding the contents of this dictionary. Future work.

#### e97e6cc
Reads a new file `non-output-components.txt` to determine the output components to cloud. We needed a more systematic way to do this than just hard coding `mqtt-input` anyway. Like with `secret_store_urls` we could read the `.py` and `.yaml` files on the fly to avoid the need for this file. Future work.

#### 0cbb5ee
Minor fixup to directory container Azure KeyVault certificate file.

# Testing
At time of writing, Docker Hub kb2ma/cloud-dev contains images for this PR.

* genericx86-64-ext -- works
* fincm3 -- **does not work** due to an issue with grpcio on Alpine; see #44
* raspberrypi4-64 -- works

Test with AWS, Azure, or GCP secrets on any platform.

Closes #39