### PR TITLE
Use tmpfs for /app/components dapr component config files

### DIFF
--- a/sensor/Dockerfile.template
+++ b/sensor/Dockerfile.template
@@ -14,7 +14,6 @@ ENV PATH=/root/.local/bin:$PATH
 WORKDIR /app
 COPY . .
 RUN chmod +x *.sh
-RUN mkdir -p /app/components
 
 RUN install_packages wget tar libstdc++
 

--- a/sensor/run.sh
+++ b/sensor/run.sh
@@ -5,6 +5,18 @@ then
     DAPR_LOGLEVEL="--log-level debug"
 fi
 
+# Ensure directory set up for component configuration files. By default use
+# tmpfs to avoid writing secrets to disk/flash. However, allow containing
+# Dockerfile/docker-compose to override setup here, for example for development.
+component_dir=/app/components
+if [ -e  "$component_dir" ]
+then
+    echo "$component_dir directory already exists"
+else
+    mkdir "$component_dir"
+    mount -t tmpfs -o mode=711 tmpfs "$component_dir"
+fi
+
 # Initialize dapr services from plugins
 python3 ./src/autoconfigure.py
 sleep 3


### PR DESCRIPTION
More secure than writing to disk/flash. Also limits directory permissions.

Performs this setup in the `run.sh` entrypoint for the Dockerfile. Allows for docker-compose or Dockerfile to override for development purposes.

Closes #46