### PR TITLE
Add delay to container startup

### DIFF
--- a/cloud/Dockerfile.template
+++ b/cloud/Dockerfile.template
@@ -64,4 +64,4 @@ RUN ./download.sh "%%BALENA_ARCH%%"
 ENV PATH /app:$PATH
 ENV PYTHONPATH /usr/src/python-packages:$PYTHONPATH
 
-CMD ["sh", "run.sh", "cloudBlock"]
+CMD ["sh", "run.sh", "cloudBlock", "30"]

--- a/cloud/run.sh
+++ b/cloud/run.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/bin/sh
+#
+# Parameters:
+#   1 -- Application ID for dapr
+#   2 -- Seconds to delay start
 
 if [ "x$DAPR_DEBUG" != "x" ]
 then
@@ -13,6 +17,11 @@ mkdir $component_dir
 mount -t tmpfs -o mode=711 tmpfs $component_dir
 mv /tmp/components/* $component_dir
 rm -rf /tmp/components
+
+# Allow time for networking and MQTT to stabilize.
+echo "Wait $2 seconds before start"
+sleep $2
+echo "Starting..."
 
 # Initialize dapr services from plugins
 python3 ./src/autoconfigure.py

--- a/examples/sensor/docker-compose.yml
+++ b/examples/sensor/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         image: kb2ma/cloud
         privileged: true
         tty: true
-        #restart: always
+        restart: always
         network_mode: host
         volumes:
             - 'cloudblockdata:/data'
@@ -22,8 +22,12 @@ services:
             - "1883:1883"
         restart: always
     sensor:
-        image: balenablocks/sensor
+        # Local build in sensor directory delays start by a configurable
+        # amount to allow for environment to stabilize; defaults to 30 seconds.
+        build: sensor
+        #image: balenablocks/sensor
         privileged: true
+        restart: always
         labels:
             io.balena.features.kernel-modules: '1'
             io.balena.features.sysfs: '1'

--- a/examples/sensor/sensor/Dockerfile
+++ b/examples/sensor/sensor/Dockerfile
@@ -1,0 +1,6 @@
+FROM balenablocks/sensor
+
+COPY delay_start.sh .
+RUN chmod a+x delay_start.sh
+
+CMD ["sh", "delay_start.sh", "30"]

--- a/examples/sensor/sensor/delay_start.sh
+++ b/examples/sensor/sensor/delay_start.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Parameters:
+#   1 -- Seconds to delay start
+
+echo "Wait $1 seconds before start"
+sleep $1
+echo "Starting..."
+
+python3 sensor.py


### PR DESCRIPTION
Adds a semi-configurable delay to startup of the cloud block container, as well as the sensor container for the sensor example. We have found that the fin (and perhaps other older systems) need some time to allow networking and MQTT to startup and stabilize. Delay defaults to 30 seconds.